### PR TITLE
When parameters aren't provided, try really hard to find them

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,20 +36,50 @@ Now, try running `surf-build`, which is a command-line app that knows how to bui
 surf-build --repo https://github.com/surf-build/surf -s 805230d579cb49ffd7e33ee060023baebaf203e5
 ```
 
-Tada! You made a build. 
+Tada! You made a build.
 
-### Setting up Continuous Build
+### Testing out Surf in your own
 
-Creating a continuous build isn't much harder - first, do the following:
+Now here's how to set it up in your own project. First, write a script in the root of the project to tell Surf how to build your project. Future versions will know how to build many common projects, but for now, we have to tell it.
+
+```sh
+echo "npm install && npm test" > build.sh
+chmod +x ./build.sh
+
+git add ./build.sh && git commit -m "Create Surf build script"
+git push
+```
+
+Now, let's test it out. First, we need to get a GitHub token:
+
 
 1. Go to https://github.com/settings/tokens to get a token
 1. Make sure to check `repo` and `gist`.
 1. Generate the token and save it off
 
+
+```
+## When you don't specify parameters, we guess them from the current directory
+export GITHUB_TOKEN='<< your token >>'
+surf-build
+```
+
+Now, let's make this build on every push:
+
+```
+## Runs locally and watches the GitHub repo for changes, then invokes
+## surf-build
+
+export GITHUB_TOKEN='<< your token >>'
+surf-client
+```
+
+### Setting up multi-platform / multi-machine continuous build
+
+Creating a multi-platform continuous build isn't much harder - first, do the following:
 Open a Console tab and run:
 
 ```sh
-export GITHUB_TOKEN='<< your token >>'
 surf-server surf-build/surf
 ```
 
@@ -68,7 +98,7 @@ That's it! Every time someone pushes a PR or change to Surf, your computer will 
 
 The most straightforward way (and one of the only ways at the moment), is to have a script at the root of the repo called `build.sh` and `build.cmd/ps1` for Windows. Future versions of Surf will know how to build common project types automatically, so you won't have to do this.
 
-## How to set up builds against GitHub PRs
+## Giving your multi-platform builds separate names
 
 Surf is great at running builds to verify your PRs, which show up here on the GitHub UI:
 

--- a/src/git-api.js
+++ b/src/git-api.js
@@ -13,10 +13,20 @@ enableThreadSafety();
 const d = require('debug')('surf:git-api');
 
 export async function getHeadForRepo(targetDirname) {
-  let repo = await Repository.open(targetDirname);
+  let repoDir = await Repository.discover(targetDirname, 0, '');
+
+  let repo = await Repository.open(repoDir);
   let commit = await repo.getHeadCommit();
 
   return commit.sha;
+}
+
+export async function getOriginForRepo(targetDirname) {
+  let repoDir = await Repository.discover(targetDirname, 0, '');
+
+  let repo = await Repository.open(repoDir);
+  let origin = await Remote.lookup(repo, 'origin');
+  return origin.pushurl() || origin.url();
 }
 
 export async function getAllWorkdirs(repoUrl) {
@@ -212,10 +222,10 @@ export async function addFilesToGist(repoUrl, targetDir, artifactDir, token=null
 export async function pushGistRepoToMaster(targetDir, token) {
   d("Opening repo");
   let repo = await Repository.open(targetDir);
-  
+
   d("Looking up origin");
   let origin = await Remote.lookup(repo, 'origin');
-  
+
   let refspec = "refs/heads/master:refs/heads/master";
   let pushopts = {
     callbacks: {
@@ -229,7 +239,7 @@ export async function pushGistRepoToMaster(targetDir, token) {
       }
     }
   };
-  
+
   d("Pushing to Gist");
   await origin.push([refspec], pushopts);
 }

--- a/src/git-api.js
+++ b/src/git-api.js
@@ -18,7 +18,7 @@ export async function getHeadForRepo(targetDirname) {
   let repo = await Repository.open(repoDir);
   let commit = await repo.getHeadCommit();
 
-  return commit.sha;
+  return commit.sha();
 }
 
 export async function getOriginForRepo(targetDirname) {

--- a/src/ref-server-api.js
+++ b/src/ref-server-api.js
@@ -5,9 +5,10 @@ import {Disposable} from 'rx';
 import {fetchAllRefsWithInfo} from './github-api';
 const d = require('debug')('surf:ref-server-api');
 
-export default function createRefServer(validNwos, port=3000) {
+export default function createRefServer(validNwos, port=null) {
   const app = express();
-
+  
+  port = port || process.env.SURF_PORT || '3000';
   app.get('/info/:owner/:name', async (req, res) => {
     try {
       if (!req.params.owner || !req.params.name) {
@@ -26,7 +27,11 @@ export default function createRefServer(validNwos, port=3000) {
       res.status(500).json({error: e.message});
     }
   });
-
+  
+  if (typeof(port) === 'string') {
+    port = parseInt(port);
+  }
+  
   let server = app.listen(port);
   return Disposable.create(() => server.close(() => {}));
 }

--- a/src/ref-server-api.js
+++ b/src/ref-server-api.js
@@ -1,0 +1,32 @@
+import _ from 'lodash';
+import express from 'express';
+import {Disposable} from 'rx';
+
+import {fetchAllRefsWithInfo} from './github-api';
+const d = require('debug')('surf:ref-server-api');
+
+export default function createRefServer(validNwos, port=3000) {
+  const app = express();
+
+  app.get('/info/:owner/:name', async (req, res) => {
+    try {
+      if (!req.params.owner || !req.params.name) {
+        throw new Error("no");
+      }
+
+      let needle = `${req.params.owner}/${req.params.name}`;
+      if (!_.find(validNwos, (x) => x === needle)) {
+        throw new Error("no");
+      }
+
+      res.json(await fetchAllRefsWithInfo(needle));
+    } catch (e) {
+      d(e.message);
+      d(e.stack);
+      res.status(500).json({error: e.message});
+    }
+  });
+
+  let server = app.listen(port);
+  return Disposable.create(() => server.close(() => {}));
+}

--- a/src/ref-server-cli.js
+++ b/src/ref-server-cli.js
@@ -1,13 +1,9 @@
 #!/usr/bin/env node
 
 import './babel-maybefill';
-
-import express from 'express';
-import {fetchAllRefsWithInfo} from './github-api';
-import _ from 'lodash';
+import {createRefServer} from './ref-server-api';
 
 const d = require('debug')('surf:ref-server');
-const app = express();
 
 const yargs = require('yargs')
   .usage(`Usage: surf-server owner/repo owner2/repo owner/repo3...
@@ -27,34 +23,21 @@ const argv = yargs.argv;
 
 function main() {
   const validNwos = argv._;
+  const port = argv.port || 3000;
+
   if (validNwos.length < 1) {
     console.error("ERROR: Supply a list of valid repositories in owner/repo format (i.e. 'rails/rails')\n");
     yargs.showHelp();
     process.exit(-1);
   }
 
-  app.get('/info/:owner/:name', async (req, res) => {
-    try {
-      if (!req.params.owner || !req.params.name) {
-        throw new Error("no");
-      }
-
-      let needle = `${req.params.owner}/${req.params.name}`;
-      if (!_.find(validNwos, (x) => x === needle)) {
-        throw new Error("no");
-      }
-
-      res.json(await fetchAllRefsWithInfo(needle));
-    } catch (e) {
-      d(e.message);
-      d(e.stack);
-      res.status(500).json({error: e.message});
-    }
-  });
-
-  let port = argv.port || 3000;
   console.log(`Listening on port ${port}`);
-  app.listen(port);
+  try {
+    createRefServer(validNwos, port);
+  } catch (e) {
+    console.error(`Failed to create Surf server: ${e.message}`);
+    d(e.stack);
+  }
 }
 
 main();

--- a/src/ref-server-cli.js
+++ b/src/ref-server-cli.js
@@ -23,7 +23,7 @@ const argv = yargs.argv;
 
 function main() {
   const validNwos = argv._;
-  const port = argv.port || 3000;
+  const port = argv.port || process.env.SURF_PORT || '3000';
 
   if (validNwos.length < 1) {
     console.error("ERROR: Supply a list of valid repositories in owner/repo format (i.e. 'rails/rails')\n");

--- a/src/run-on-every-ref-cli.js
+++ b/src/run-on-every-ref-cli.js
@@ -5,7 +5,7 @@ import './babel-maybefill';
 import request from 'request-promise';
 import {getOriginForRepo} from './git-api';
 import {getNwoFromRepoUrl} from './github-api';
-import {createRefServer} from './ref-server-api';
+import createRefServer from './ref-server-api';
 import BuildMonitor from './build-monitor';
 
 const d = require('debug')('surf:run-on-every-ref');
@@ -42,6 +42,7 @@ async function main(testServer=null, testRepo=null, testCmdWithArgs=null) {
   if (!repo) {
     try {
       repo = await getOriginForRepo('.');
+      console.error(`Repository not specified, using current directory: ${repo}`);
     } catch (e) {
       console.error("Repository not specified and current directory is not a Git repo");
       d(e.stack);
@@ -52,12 +53,12 @@ async function main(testServer=null, testRepo=null, testCmdWithArgs=null) {
   }
 
   if (!server) {
-    console.error(```
+    console.error(`
 **** Becoming a Surf Server ****
 
 If you're only setting up a single build client, this is probably what you want.
 If you're setting up more than one, you'll want to run 'surf-server' somewhere,
-then pass '-s' to all of your build clients.```);
+then pass '-s' to all of your build clients.`);
 
     let nwo = getNwoFromRepoUrl(repo);
     createRefServer([nwo]);

--- a/src/run-on-every-ref-cli.js
+++ b/src/run-on-every-ref-cli.js
@@ -11,13 +11,13 @@ import BuildMonitor from './build-monitor';
 const d = require('debug')('surf:run-on-every-ref');
 
 const yargs = require('yargs')
-  .usage(`Usage: surf-client -s http://some.server -r https://github.com/some/repo -- command arg1 arg2 arg3...
+  .usage(`Usage: surf-client -r https://github.com/some/repo -- command arg1 arg2 arg3...
 Monitors a GitHub repo and runs a command for each changed branch / PR.`)
   .help('h')
   .alias('s', 'server')
-  .describe('s', 'The Surf server to connect to')
+  .describe('s', 'The Surf server to connect to for multi-machine builds')
   .alias('r', 'repo')
-  .describe('r', 'The URL of the repository to monitor')
+  .describe('r', 'The URL of the repository to monitor. Defaults to the repo in the current directory')
   .alias('j', 'jobs')
   .describe('j', 'The number of concurrent jobs to run. Defaults to 2')
   .alias('h', 'help')


### PR DESCRIPTION
This PR tries to fill in parameters to the CLI apps with reasonable defaults - for example, if I run `surf-build` in my project dir, it's probably a good guess that I want to build my project at the current SHA1