### PR TITLE
Create a basic status page

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,13 @@
   "homepage": "https://github.com/paulcbetts/surf-build",
   "dependencies": {
     "babel-polyfill": "^6.3.14",
+    "bulma": "0.0.8",
     "debug": "^2.2.0",
     "express": "^4.13.4",
     "fs-extra": "^0.26.4",
     "ini": "^1.3.4",
     "iso8601": "^1.1.1",
+    "jade": "^1.11.0",
     "lodash": "^4.0.0",
     "lru-cache": "^4.0.0",
     "mkdirp": "^0.5.1",

--- a/src/ref-server-api.js
+++ b/src/ref-server-api.js
@@ -14,9 +14,15 @@ function setupRouting(app, validNwos) {
   app.get('/', (req, res) => {
     res.render('status', {
       version: pkgJson.version,
+      serversAreDown: true,
       serverList: [
         {
           nwo: 'surf-build/surf',
+          lastChecked: (new Date()).toLocaleString(),
+          failed: true
+        },
+        {
+          nwo: 'rails/rails',
           lastChecked: (new Date()).toLocaleString()
         }
       ]

--- a/src/ref-server-api.js
+++ b/src/ref-server-api.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import path from 'path';
 import express from 'express';
 import {Disposable} from 'rx';
+import pkgJson from '../package.json';
 
 import {fetchAllRefsWithInfo} from './github-api';
 const d = require('debug')('surf:ref-server-api');
@@ -11,9 +12,17 @@ function setupRouting(app, validNwos) {
 
   app.use('/bulma', express.static(bulma));
   app.get('/', (req, res) => {
-    res.render('status', {});
+    res.render('status', {
+      version: pkgJson.version,
+      serverList: [
+        {
+          nwo: 'surf-build/surf',
+          lastChecked: (new Date()).toLocaleString()
+        }
+      ]
+    });
   });
-  
+
   app.get('/info/:owner/:name', async (req, res) => {
     try {
       if (!req.params.owner || !req.params.name) {

--- a/src/ref-server-api.js
+++ b/src/ref-server-api.js
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import path from 'path';
 import express from 'express';
 import {Disposable} from 'rx';
 
@@ -6,6 +7,9 @@ import {fetchAllRefsWithInfo} from './github-api';
 const d = require('debug')('surf:ref-server-api');
 
 function setupRouting(app, validNwos) {
+  let bulma = path.resolve(__dirname, '..', 'node_modules', 'bulma', 'css');
+
+  app.use('/bulma', express.static(bulma));
   app.get('/', (req, res) => {
     res.render('status', {});
   });

--- a/src/ref-server-api.js
+++ b/src/ref-server-api.js
@@ -5,10 +5,11 @@ import {Disposable} from 'rx';
 import {fetchAllRefsWithInfo} from './github-api';
 const d = require('debug')('surf:ref-server-api');
 
-export default function createRefServer(validNwos, port=null) {
-  const app = express();
+function setupRouting(app, validNwos) {
+  app.get('/', (req, res) => {
+    res.render('status', {});
+  });
   
-  port = port || process.env.SURF_PORT || '3000';
   app.get('/info/:owner/:name', async (req, res) => {
     try {
       if (!req.params.owner || !req.params.name) {
@@ -27,7 +28,16 @@ export default function createRefServer(validNwos, port=null) {
       res.status(500).json({error: e.message});
     }
   });
+}
+
+export default function createRefServer(validNwos, port=null) {
+  const app = express();
+  app.set('view engine', 'jade');
+
+  setupRouting(app, validNwos);
   
+  port = port || process.env.SURF_PORT || '3000';
+
   if (typeof(port) === 'string') {
     port = parseInt(port);
   }

--- a/views/status.jade
+++ b/views/status.jade
@@ -1,5 +1,6 @@
 html
   head
+    link(rel='stylesheet' type='text/css' href='/bulma/bulma.css')
     title= 'Hello'
   body
     h1= 'Derp'

--- a/views/status.jade
+++ b/views/status.jade
@@ -15,13 +15,20 @@ html(lang=en)
           h1.hero.title.is-1 Build Server Status
 
     if serverList
-      section.hero.is-primary.is-medium
+      section.hero.is-medium(class="#{serversAreDown ? 'is-danger' : ''}")
         .hero-content
           .container.content
             each server in serverList
               article.media
-                .media-content.structure-item.is-structure-right
-                  p= server.nwo
+                figure.media-image
+                  span
+                    i.fa.fa-3x(class="#{server.failed ? 'fa-times-circle' : 'fa-check-circle-o'}")=''
+
+                .media-content
+                  .content
+                    strong= server.nwo
+                    br
+                    p= server.lastChecked
     else
       section.hero.is-info.is-large
         .hero-content

--- a/views/status.jade
+++ b/views/status.jade
@@ -1,0 +1,5 @@
+html
+  head
+    title= 'Hello'
+  body
+    h1= 'Derp'

--- a/views/status.jade
+++ b/views/status.jade
@@ -17,20 +17,20 @@ html(lang=en)
           h1.hero.title.is-1 Build Server Status
 
     if serverList
-      section.hero.is-medium(class="#{serversAreDown ? 'is-danger' : ''}")
+      section.hero.is-medium
         .hero-content
           .container.content
             each server in serverList
-              article.media
+              article.media(class="#{server.failed ? 'is-danger' : ''}")
                 figure.media-image
                   span
-                    i.fa.fa-3x(class="#{server.failed ? 'fa-times-circle' : 'fa-check-circle-o'}")=''
+                    i.fa.fa-3x(class="#{server.failed ? 'fa-times-circle is-danger' : 'fa-check-circle-o'}")=''
 
                 .media-content
                   .content
                     strong= server.nwo
                     br
-                    p= server.lastChecked
+                    p= 'Last seen at ' + server.lastChecked
     else
       section.hero.is-info.is-large
         .hero-content

--- a/views/status.jade
+++ b/views/status.jade
@@ -1,6 +1,37 @@
-html
+html(lang=en)
   head
     link(rel='stylesheet' type='text/css' href='/bulma/bulma.css')
-    title= 'Hello'
+    link(rel='stylesheet' type='text/css' href='https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css')
+    title 'Surf Build Server'
+
   body
-    h1= 'Derp'
+    header.header
+      .container
+        a.header-item(href='/') Home
+
+    section.hero
+      .hero-content
+        .container
+          h1.hero.title.is-1 Build Server Status
+
+    if serverList
+      section.hero.is-primary.is-medium
+        .hero-content
+          .container.content
+            each server in serverList
+              article.media
+                .media-content.structure-item.is-structure-right
+                  p= server.nwo
+    else
+      section.hero.is-info.is-large
+        .hero-content
+          .container.content
+            p.title No build clients at the moment
+            p.subtitle See the #[a(href='https://github.com/surf-build/surf#giving-your-multi-platform-builds-separate-names') documentation] for more information on how to set up build clients
+
+    footer.footer
+      .container
+        .content.is-centered
+          p Surf #{version} is made with #[span.fa.fa-heart] by Paul Betts
+          p.icon
+            a.fa.fa-2x.fa-github(href='https://github.com/surf-build/surf')

--- a/views/status.jade
+++ b/views/status.jade
@@ -1,5 +1,7 @@
 html(lang=en)
   head
+    meta(http-equiv='X-UA-Compatible' content='IE=edge')
+    meta(name='viewport' content='width=device-width, initial-scale=1')
     link(rel='stylesheet' type='text/css' href='/bulma/bulma.css')
     link(rel='stylesheet' type='text/css' href='https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css')
     title 'Surf Build Server'


### PR DESCRIPTION
This PR creates a status page that lets you see the currently polling build clients

## TODO:

- [x] Get a dummy page up
- [x] Get a sketch of what we want in there
- [x] Populate it with actual data
- [ ] Allow build servers to be dropped from the list