### PR TITLE
Handle SSH Remote URLs

### DIFF
--- a/src/build-project-cli.js
+++ b/src/build-project-cli.js
@@ -5,7 +5,7 @@ import './babel-maybefill';
 import path from 'path';
 import mkdirp from 'mkdirp';
 import { cloneOrFetchRepo, cloneRepo, checkoutSha, getWorkdirForRepoUrl, getTempdirForRepoUrl, getOriginForRepo, getHeadForRepo } from './git-api';
-import { getNwoFromRepoUrl, postCommitStatus, createGist } from './github-api';
+import { getSanitizedRepoUrl, getNwoFromRepoUrl, postCommitStatus, createGist } from './github-api';
 import { determineBuildCommand, runBuildCommand, uploadBuildArtifacts } from './build-api';
 import { fs, rimraf } from './promisify';
 
@@ -70,7 +70,7 @@ export async function main(testSha=null, testRepo=null, testName=null) {
 
   if (!repo) {
     try {
-      repo = await getOriginForRepo('.');
+      repo = getSanitizedRepoUrl(await getOriginForRepo('.'));
     } catch (e) {
       console.error("Repository not specified and current directory is not a Git repo");
       d(e.stack);

--- a/src/github-api.js
+++ b/src/github-api.js
@@ -28,12 +28,12 @@ const httpsRemoteUri = /https?:\/\//i;
 export function getSanitizedRepoUrl(repoUrl) {
   if (repoUrl.match(httpsRemoteUri)) return repoUrl;
   let m = repoUrl(sshRemoteUrl);
-
+  
   if (!m) {
     d(`URL ${repoUrl} seems totally bogus`);
     return repoUrl;
   }
-
+  
   if (m[1] === 'github.com') {
     return `https://github.com/${m[2]}`;
   } else {
@@ -44,9 +44,8 @@ export function getSanitizedRepoUrl(repoUrl) {
 
 export function getNwoFromRepoUrl(repoUrl) {
   // Fix up SSH repo origins
-  if (repoUrl.match(/^git@.*:.*\.git$/i)) {
-    return repoUrl.split(':')[1].replace(/\.git$/, '');
-  }
+  let m = repoUrl.match(sshRemoteUrl);
+  if (m) { return m[2]; }
 
   let u = url.parse(repoUrl);
   return u.path.slice(1).replace(/\.git$/, '');

--- a/src/github-api.js
+++ b/src/github-api.js
@@ -22,6 +22,26 @@ function apiUrl(path, gist=false) {
   }
 }
 
+const sshRemoteUrl = /^git@(.*):([^.]*)(\.git)?$/i;
+const httpsRemoteUri = /https?:\/\//i;
+
+export function getSanitizedRepoUrl(repoUrl) {
+  if (repoUrl.match(httpsRemoteUri)) return repoUrl;
+  let m = repoUrl(sshRemoteUrl);
+
+  if (!m) {
+    d(`URL ${repoUrl} seems totally bogus`);
+    return repoUrl;
+  }
+
+  if (m[1] === 'github.com') {
+    return `https://github.com/${m[2]}`;
+  } else {
+    let host = process.env.GITHUB_ENTERPRISE_URL || `https://${m[1]}`;
+    return `${host}/${m[2]}`;
+  }
+}
+
 export function getNwoFromRepoUrl(repoUrl) {
   // Fix up SSH repo origins
   if (repoUrl.match(/^git@.*:.*\.git$/i)) {

--- a/src/github-api.js
+++ b/src/github-api.js
@@ -27,7 +27,7 @@ const httpsRemoteUri = /https?:\/\//i;
 
 export function getSanitizedRepoUrl(repoUrl) {
   if (repoUrl.match(httpsRemoteUri)) return repoUrl;
-  let m = repoUrl(sshRemoteUrl);
+  let m = repoUrl.match(sshRemoteUrl);
   
   if (!m) {
     d(`URL ${repoUrl} seems totally bogus`);

--- a/src/run-on-every-ref-cli.js
+++ b/src/run-on-every-ref-cli.js
@@ -4,7 +4,7 @@ import './babel-maybefill';
 
 import request from 'request-promise';
 import {getOriginForRepo} from './git-api';
-import {getNwoFromRepoUrl} from './github-api';
+import {getSanitizedRepoUrl, getNwoFromRepoUrl} from './github-api';
 import createRefServer from './ref-server-api';
 import BuildMonitor from './build-monitor';
 
@@ -41,7 +41,7 @@ async function main(testServer=null, testRepo=null, testCmdWithArgs=null) {
 
   if (!repo) {
     try {
-      repo = await getOriginForRepo('.');
+      repo = getSanitizedRepoUrl(await getOriginForRepo('.'));
       console.error(`Repository not specified, using current directory: ${repo}`);
     } catch (e) {
       console.error("Repository not specified and current directory is not a Git repo");


### PR DESCRIPTION
If we run a simple `surf-build` against a repo that has an SSH URL for a remote, we need to transmogrify it to an HTTPS URL.

## TODO:

- [ ] Make sure this actually works
