### PR TITLE
Add surf-publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "jade": "^1.11.0",
     "lodash": "^4.12.0",
     "lru-cache": "^4.0.1",
+    "mime-types": "^2.1.11",
     "mkdirp": "^0.5.1",
     "nodegit": "0.13.0",
     "parse-link-header": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "surf-server": "./lib/ref-server-cli.js",
     "surf-client": "./lib/run-on-every-ref-cli.js",
     "surf-build": "./lib/build-project-cli.js",
-    "surf-clean": "./lib/clean-workdirs-cli.js"
+    "surf-clean": "./lib/clean-workdirs-cli.js",
+    "surf-publish": "./lib/publish-tag-cli.js"
   },
   "scripts": {
     "compile": "babel -d lib/ src/",

--- a/src/git-api.js
+++ b/src/git-api.js
@@ -1,7 +1,6 @@
 import crypto from 'crypto';
 import path from 'path';
 import _ from 'lodash';
-import ini from 'ini';
 
 import { Repository, Clone, Checkout, Cred, Reference, Signature, Remote, enableThreadSafety } from 'nodegit';
 import { getNwoFromRepoUrl } from './github-api';

--- a/src/github-api.js
+++ b/src/github-api.js
@@ -86,7 +86,6 @@ export async function gitHub(uri, token=null, body=null, extraHeaders=null) {
   }
     
   if (_.isNumber(body) || body instanceof Buffer || body instanceof fs.ReadStream) {
-    d("Deleting JSON!");
     delete opts.json;
   }
 
@@ -195,7 +194,6 @@ export function createRelease(nwo, tag, token=null) {
     draft: true
   };
   
-  d(JSON.stringify(body));
   return gitHub(apiUrl(`repos/${nwo}/releases`), token, body);
 }
 

--- a/src/github-api.js
+++ b/src/github-api.js
@@ -189,6 +189,7 @@ export function fetchStatusesForCommit(nwo, sha, token=null) {
 export function createRelease(nwo, tag, token=null) {
   let body = { 
     tag_name: tag,
+    target_committish: tag,
     name: `${nwo.split('/')[1]} @ ${tag}`,
     body: 'To be written',
     draft: true

--- a/src/github-api.js
+++ b/src/github-api.js
@@ -163,7 +163,7 @@ export function fetchAllTags(nwo, token=null) {
   return githubPaginate(apiUrl(`repos/${nwo}/tags?per_page=100`), token, 60*1000);
 }
 
-export function fetchStatusesForRef(nwo, sha, token=null) {
+export function fetchStatusesForCommit(nwo, sha, token=null) {
   return githubPaginate(apiUrl(`repos/${nwo}/commits/${sha}/statuses?per_page=100`), token, 60*1000);
 }
 

--- a/src/github-api.js
+++ b/src/github-api.js
@@ -158,3 +158,22 @@ export function createGist(description, files, publicGist=false, token=null) {
   let body = { files, description, "public": publicGist };
   return gitHub(apiUrl('gists', true), token || process.env.GIST_TOKEN, body);
 }
+
+export function fetchAllTags(nwo, token=null) {
+  return githubPaginate(apiUrl(`repos/${nwo}/tags?per_page=100`), token, 60*1000);
+}
+
+export function fetchStatusesForRef(nwo, sha, token=null) {
+  return githubPaginate(apiUrl(`repos/${nwo}/commits/${sha}/statuses?per_page=100`), token, 60*1000);
+}
+
+export function createRelease(nwo, tag, token=null) {
+  let body = { 
+    tag_name: tag,
+    name: `${nwo.split('/')[1]} @ ${tag}`,
+    body: 'To be written',
+    draft: true
+  };
+  
+  return gitHub(apiUrl('repos/${nwo}/releases'), token, body);
+}

--- a/src/publish-tag-cli.js
+++ b/src/publish-tag-cli.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+import './babel-maybefill';
+import main from './publish-tag-main';
+
+const d = require('debug')('surf:surf-publish');
+
+const yargs = require('yargs')
+  .usage(`Usage: surf-publish -r http://github.com/some/repo -t some-tag
+Creates a release for the given tag by downloading all of the build 
+artifacts and reuploading them`)
+  .alias('r', 'repo')
+  .describe('repo', 'The repository to clone')
+  .alias('t', 'tag')
+  .describe('tag', 'The tag to download releases for')
+  .epilog(`
+Some useful environment variables:
+
+GITHUB_TOKEN - the GitHub (.com or Enterprise) API token to use. Must be provided.
+GIST_TOKEN - the GitHub (.com or Enterprise) API token to use to clone the build Gists.
+`);
+
+const argv = yargs.argv;
+
+main(argv, () => yargs.showHelp())
+  .then(() => process.exit(0))
+  .catch((e) => {
+    console.log(`Fatal Error: ${e.message}`);
+    d(e.stack);
+
+    process.exit(-1);
+  });

--- a/src/publish-tag-main.js
+++ b/src/publish-tag-main.js
@@ -1,0 +1,59 @@
+import path from 'path';
+import mkdirp from 'mkdirp';
+
+import { getNwoFromRepoUrl, fetchAllTags, fetchStatusesForCommit } from './github-api';
+import { retryPromise } from './promise-array';
+
+const d = require('debug')('surf:surf-publish');
+
+function getRootAppDir() {
+  let ret = null;
+
+  switch (process.platform) {
+  case 'win32':
+    ret = path.join(process.env.LOCALAPPDATA, 'surf');
+    break;
+  case 'darwin':
+    ret = path.join(process.env.HOME, 'Library', 'Application Support', 'surf');
+    break;
+  default:
+    ret = path.join(process.env.HOME, '.config', 'surf');
+    break;
+  }
+
+  mkdirp.sync(ret);
+  return ret;
+}
+
+export default async function main(argv, showHelp) {
+  let repo = argv.repo || process.env.SURF_REPO;
+  let tag = argv.tag;
+  
+  if (argv.help) {
+    showHelp();
+    process.exit(0);
+  }
+  
+  if (!tag || !repo) {
+    d(`Tag or repo not set: ${tag}, ${repo}`);
+    
+    showHelp();
+    process.exit(-1);
+  }
+  
+  // 1. Look up tag
+  // 2. Run down CI statuses for tag SHA1
+  // 3. Convert URLs to something clonable
+  // 4. Clone them all
+  // 5. Find the files
+  // 6. Upload them all
+  let nwo = getNwoFromRepoUrl(repo);
+  let ourTag = (await fetchAllTags(nwo)).find((x) => x.name === tag);
+  
+  if (!ourTag) {
+    throw new Error(`Couldn't find a matching tag on GitHub for ${tag}`);
+  }
+  
+  let statuses = await fetchStatusesForCommit(nwo, ourTag.commit.sha);
+  console.log(JSON.stringify(statuses));
+}


### PR DESCRIPTION
This PR creates a new command `surf-publish` that will publish artifacts to GitHub as a Release given a Tag:

```
Creates a release for the given tag by downloading all of the build
artifacts and reuploading them

Options:
  -r, --repo  The repository to clone
  -t, --tag   The tag to download releases for

Some useful environment variables:

GITHUB_TOKEN - the GitHub (.com or Enterprise) API token to use. Must be
provided.
GIST_TOKEN - the GitHub (.com or Enterprise) API token to use to clone the build
Gists.
```