### PR TITLE
Add surf-download

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,27 @@ Options:
   Gists.
 ```
 
+### `surf-download`
+
+Downloads all of the assets from a Release on GitHub.
+
+```
+Usage: surf-download -r http://github.com/some/repo -t some-tag
+Download all of the artifacts for a given Release
+
+Options:
+  --target    The directory to download files to
+  -r, --repo  The repository to clone
+  -t, --tag   The tag to download releases for
+
+
+Some useful environment variables:
+
+GITHUB_TOKEN - the GitHub (.com or Enterprise) API token to use. Must be
+provided.
+```
+
+
 ### `surf-clean`
 
 Surf will leave lots of temporary directories around for work directories by-default. `surf-clean` will mop up ones that are no longer mapped to current branches.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "surf-client": "./lib/run-on-every-ref-cli.js",
     "surf-build": "./lib/build-project-cli.js",
     "surf-clean": "./lib/clean-workdirs-cli.js",
-    "surf-publish": "./lib/publish-tag-cli.js"
+    "surf-publish": "./lib/publish-tag-cli.js",
+    "surf-download": "./lib/download-release-cli.js"
   },
   "scripts": {
     "compile": "babel -d lib/ src/",

--- a/src/download-release-cli.js
+++ b/src/download-release-cli.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+import './babel-maybefill';
+import main from './download-release-main';
+
+const d = require('debug')('surf:surf-download');
+
+const yargs = require('yargs')
+  .usage(`Usage: surf-download -r http://github.com/some/repo -t some-tag
+Download all of the artifacts for a given Release`)
+  .alias('r', 'repo')
+  .describe('repo', 'The repository to clone')
+  .alias('t', 'tag')
+  .describe('tag', 'The tag to download releases for')
+  .describe('target', 'The directory to download files to')
+  .epilog(`
+Some useful environment variables:
+
+GITHUB_TOKEN - the GitHub (.com or Enterprise) API token to use. Must be provided.
+`);
+
+const argv = yargs.argv;
+
+main(argv, () => yargs.showHelp())
+  .then(() => process.exit(0))
+  .catch((e) => {
+    console.log(`Fatal Error: ${e.message}`);
+    d(e.stack);
+
+    process.exit(-1);
+  });

--- a/src/download-release-main.js
+++ b/src/download-release-main.js
@@ -1,0 +1,33 @@
+import path from 'path';
+
+import { getNwoFromRepoUrl, getReleaseByTag, downloadReleaseAsset } from './github-api';
+import { retryPromise, asyncMap } from './promise-array';
+
+const d = require('debug')('surf:surf-publish');
+
+export default async function main(argv, showHelp) {
+  let repo = argv.repo || process.env.SURF_REPO;
+  let tag = argv.tag;
+  let target = argv.target || path.resolve('.');
+
+  if (argv.help) {
+    showHelp();
+    process.exit(0);
+  }
+
+  if (!tag || !repo) {
+    d(`Tag or repo not set: ${tag}, ${repo}`);
+
+    showHelp();
+    process.exit(-1);
+  }
+
+  let nwo = getNwoFromRepoUrl(repo);
+  let release = (await getReleaseByTag(nwo, tag)).result;
+  await asyncMap(release.assets, (asset) => {
+    if (asset.state !== 'uploaded') return Promise.resolve(true);
+    let file = path.join(target, asset.name);
+
+    return retryPromise(() => downloadReleaseAsset(nwo, asset.id, file));
+  });
+}

--- a/src/github-api.js
+++ b/src/github-api.js
@@ -5,6 +5,7 @@ import fs from 'fs';
 import url from 'url';
 import _ from 'lodash';
 import request from 'request-promise';
+import requestOg from 'request';
 import parseLinkHeader from 'parse-link-header';
 import pkg from '../package.json';
 import {asyncMap} from './promise-array';
@@ -61,7 +62,7 @@ export function getIdFromGistUrl(gistUrl) {
   return s[2] || s[1];
 }
 
-export async function gitHub(uri, token=null, body=null, extraHeaders=null) {
+export async function gitHub(uri, token=null, body=null, extraHeaders=null, targetFile=null) {
   let tok = token || process.env.GITHUB_TOKEN;
 
   d(`Fetching GitHub URL: ${uri}`);
@@ -87,6 +88,20 @@ export async function gitHub(uri, token=null, body=null, extraHeaders=null) {
     
   if (_.isNumber(body) || body instanceof Buffer || body instanceof fs.ReadStream) {
     delete opts.json;
+  }
+
+  if (targetFile) {
+    delete opts.json;
+
+    await new Promise((res,rej) => {
+      let str = requestOg(opts)
+        .pipe(fs.createWriteStream(targetFile));
+
+      str.on('finish', () => res());
+      str.on('error', (e) => rej(e));
+    });
+
+    return { result: targetFile, headers: {}};
   }
 
   let ret = null;

--- a/src/github-api.js
+++ b/src/github-api.js
@@ -224,3 +224,12 @@ export function uploadFileToRelease(releaseInfo, targetFile, fileName, token=nul
   d(JSON.stringify(contentType));
   return gitHub(uploadUrl, token, fs.createReadStream(targetFile), contentType);
 }
+
+export function getReleaseByTag(nwo, tag, token=null) {
+  return gitHub(apiUrl(`repos/${nwo}/releases/tags/${tag}`), token);
+}
+
+export function downloadReleaseAsset(nwo, assetId, targetFile, token=null) {
+  let headers = { "Accept": "application/octet-stream" };
+  return gitHub(apiUrl(`repos/${nwo}/releases/assets/${assetId}`), token, null, headers, targetFile);
+}


### PR DESCRIPTION
This PR adds a new `surf-download` command that downloads all of the artifacts for a Release from GitHub (whether Surf created them or not)

```
Usage: surf-download -r http://github.com/some/repo -t some-tag
Download all of the artifacts for a given Release

Options:
  --target    The directory to download files to
  -r, --repo  The repository to clone
  -t, --tag   The tag to download releases for


Some useful environment variables:

GITHUB_TOKEN - the GitHub (.com or Enterprise) API token to use. Must be
provided.
```