### PR TITLE
Make ref servers fast again

### DIFF
--- a/src/github-api.js
+++ b/src/github-api.js
@@ -177,7 +177,6 @@ export async function fetchAllRefsWithInfo(nwo) {
 
   _.each(refs, (ref) => {
     ref.object.commit = commitInfo[ref.object.url];
-    console.log(ref.ref.replace(/^refs\/heads\//, ''));
     ref.object.pr = refToPR[ref.ref.replace(/^refs\/heads\//, '')];
   });
 

--- a/src/github-api.js
+++ b/src/github-api.js
@@ -157,6 +157,14 @@ export async function githubPaginate(uri, token=null, maxAge=null) {
   return ret;
 }
 
+export function fetchAllOpenPRs(nwo) {
+  return githubPaginate(apiUrl(`repos/${nwo}/pulls?state=open`), null, 60*1000);
+}
+
+export function fetchSingleRef(nwo, ref) {
+  return cachedGitHub(apiUrl(`repos/${nwo}/git/refs/heads/${ref}`));
+}
+
 export function fetchAllRefs(nwo) {
   return githubPaginate(apiUrl(`repos/${nwo}/git/refs?per_page=100`), null, 60*1000);
 }

--- a/src/github-api.js
+++ b/src/github-api.js
@@ -131,15 +131,6 @@ export async function cachedGitHub(uri, token=null, maxAge=null) {
   return ret;
 }
 
-export function filterBoringRefs(refs) {
-  return _.filter(refs, (ref) => {
-    if (ref.ref.match(/__gh/)) return false;
-    if (ref.ref.match(/\/merge$/i)) return false;
-
-    return true;
-  });
-}
-
 export async function githubPaginate(uri, token=null, maxAge=null) {
   let next = uri;
   let ret = [];
@@ -162,11 +153,7 @@ export function fetchAllOpenPRs(nwo) {
 }
 
 export function fetchSingleRef(nwo, ref) {
-  return cachedGitHub(apiUrl(`repos/${nwo}/git/refs/heads/${ref}`));
-}
-
-export function fetchAllRefs(nwo) {
-  return githubPaginate(apiUrl(`repos/${nwo}/git/refs?per_page=100`), null, 60*1000);
+  return cachedGitHub(apiUrl(`repos/${nwo}/git/refs/heads/${ref}`), null, 30*1000);
 }
 
 export async function fetchAllRefsWithInfo(nwo) {


### PR DESCRIPTION
This PR makes surf-server and surf-client only fetch open PRs, which is much, much faster than trying to fetch all refs