### PR TITLE
Use the ref's repo name when checking refs

### DIFF
--- a/src/github-api.js
+++ b/src/github-api.js
@@ -175,10 +175,11 @@ export async function fetchAllRefsWithInfo(nwo) {
     await asyncMap(
       refList, 
       async (ref) => {
+        let repoName = refToPR[ref].head.repo.full_name;
         try {
-          return (await fetchSingleRef(nwo, ref)).result;
+          return (await fetchSingleRef(repoName, ref)).result;
         } catch (e) {
-          d(`Tried to fetch ref ${ref.ref} but it failed: ${e.message}`);
+          d(`Tried to fetch ref ${repoName}:${ref} but it failed: ${e.message}`);
           return null;
         }
       }));


### PR DESCRIPTION
For PRs from forks. using the `head.repo.full_name` makes sure the ref downloading/checking works as intended (it doesn't seem to affect feature-branch PRs).

Also added a bit more info to the debug message as well as made sure it's not printing `undefined`.

This was a simple attempt at fixing - I tested against our repo (with various PRs from forks) and it worked as intended - let me know if there's a better/cleaner way to do it.

Fixes #44 