### PR TITLE
Correct bundle lookup affinity when does not exist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,16 @@ os:
 
 env:
   - DEBUG="*,-babel"
-  
+
 addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-      - libstdc++-4.9-dev
+      - gcc-4.9
+      - libstdc++6
 
 install:
-  - npm install -g surf-build@1.0.0-beta.3 
+  - npm install -g surf-build@1.0.0-beta.3
 script:
   - surf-build -n "surf-travis-$TRAVIS_OS_NAME"

--- a/src/build-discoverers/danger.js
+++ b/src/build-discoverers/danger.js
@@ -14,20 +14,20 @@ export default class DangerBuildDiscoverer extends BuildDiscoverBase {
   }
 
   async getAffinityForRootDir() {
-    let dangerFile = path.join(this.rootDir, 'Dangerfile');
-    let exists = await statNoException(dangerFile);
+    const bailedAffinity = 0;
+    const dangerFile = path.join(this.rootDir, 'Dangerfile');
+    const exists = await statNoException(dangerFile);
 
-    if (process.env.SURF_DISABLE_DANGER) return 0;
-    if (!exists) return;
+    if (process.env.SURF_DISABLE_DANGER || !exists) return bailedAffinity;
 
     // If we can't find Bundler in PATH, bail
     if (findActualExecutable('bundle').cmd === 'bundle') {
       console.log(`A Dangerfile exists but can't find Ruby and Bundler in PATH, skipping`);
-      return 0;
+      return bailedAffinity;
     }
 
     d(`Found Dangerfile at ${dangerFile}`);
-    return exists ? 100 : 0;
+    return exists ? 100 : bailedAffinity;
   }
 
   async getBuildCommand() {


### PR DESCRIPTION
This PR fixes behaivor of `getAffinityRootDir` for danger to return correct affinity number for certain cases. Discoverer expects affinity as number, while lookup for danger can possibly return `undefined` instead - makes discoverer think danger is available. Also updated discoverer to check value is available as well. 