### PR TITLE
Don't add discoverers with an affinity of 0.

### DIFF
--- a/src/build-api.js
+++ b/src/build-api.js
@@ -25,8 +25,8 @@ export async function determineBuildCommands(rootPath, sha) {
   let activeDiscoverers = [];
 
   let mainDiscoverer = await asyncReduce(discoverers, async (acc, x) => {
-    let affinity = await x.getAffinityForRootDir();
-    if (affinity && affinity < 1) return acc;
+    let affinity = await x.getAffinityForRootDir() || 0;
+    if (affinity < 1) return acc;
 
     if (x.shouldAlwaysRun) {
       activeDiscoverers.push({ affinity, discoverer: x});


### PR DESCRIPTION
If a discoverer returned 0 for its affinity, such as the case of the Danger discoverer when it
isn't supposed to run, the current filter would add it anyway since zero evaluates to false.

Fixes #53.