### PR TITLE
Use the PR information to cache refs 

### DIFF
--- a/src/github-api.js
+++ b/src/github-api.js
@@ -162,7 +162,7 @@ export async function fetchSingleRef(nwo, ref, shaHint=null) {
   }
 
   ret = await cachedGitHub(apiUrl(`repos/${nwo}/git/refs/heads/${ref}`), null, 30*1000);
-  refCache.set(shaHint, ret);
+  refCache.set(ret.result.object.sha, ret);
   return ret;
 }
 


### PR DESCRIPTION
This PR drastically reduces the number of GitHub API calls we make, by caching ref information by SHA1, then using the PR info to see if we've already seen this sha before.