### PR TITLE
Allow surf-clean to be run inside surf-build successfully

### DIFF
--- a/src/build-api.js
+++ b/src/build-api.js
@@ -85,6 +85,7 @@ export function runAllBuildCommands(cmds, rootDir, sha, tempDir) {
 export function runBuildCommand(cmd, args, rootDir, sha, tempDir) {
   let envToAdd = {
     'SURF_SHA1': sha,
+    'SURF_ORIGINAL_TMPDIR': process.env.TMPDIR || process.env.TEMP || '/tmp',
     'TMPDIR': tempDir,
     'TEMP': tempDir,
     'TMP': tempDir

--- a/src/git-api.js
+++ b/src/git-api.js
@@ -44,7 +44,7 @@ export async function getOriginForRepo(targetDirname) {
 }
 
 export async function getAllWorkdirs(repoUrl) {
-  let tmp = process.env.TMPDIR || process.env.TEMP || '/tmp';
+  let tmp = process.env.SURF_ORIGINAL_TMPDIR || process.env.TMPDIR || process.env.TEMP || '/tmp';
   let ret = await fs.readdir(tmp);
 
   return _.reduce(ret, (acc, x) => {


### PR DESCRIPTION
This PR allows you to run `surf-clean` inside of `surf-build` by escaping the fake TMPDIR we set up