### PR TITLE
remove throw to have correct status in github

### DIFF
--- a/src/build-project-main.js
+++ b/src/build-project-main.js
@@ -240,8 +240,4 @@ async function realMain(argv, showHelp) {
   if (buildPassed && !process.env.DEBUG) {
     await rimraf(tempDir);
   }
-
-  if (!buildPassed) {
-    throw new Error(buildOutput);
-  }
 }


### PR DESCRIPTION
removed the throw so that the build status is not overitten by a status without url to gist.