### PR TITLE
Don't report failed builds as errors

### DIFF
--- a/src/build-api.js
+++ b/src/build-api.js
@@ -100,8 +100,11 @@ export function runBuildCommand(cmd, args, rootDir, sha, tempDir) {
   return spawnDetached(cmd, args, opts);
 }
 
-export async function uploadBuildArtifacts(gistId, gistCloneUrl, artifactDirs, token) {
+export async function uploadBuildArtifacts(gistId, gistCloneUrl, artifactDirs, buildLog, token) {
   let targetDir = getGistTempdir(gistId);
+
+  // Add the build log even though it isn't an artifact
+  await addFilesToGist(gistCloneUrl, targetDir, buildLog, token);
 
   for (let artifactDir of artifactDirs) {
     await addFilesToGist(gistCloneUrl, targetDir, artifactDir, token);

--- a/src/build-project-cli.js
+++ b/src/build-project-cli.js
@@ -38,7 +38,7 @@ if (argv.version) {
 }
 
 main(argv, () => yargs.showHelp())
-  .then(() => process.exit(0))
+  .then((x) => process.exit(x))
   .catch((e) => {
     console.log(`Fatal Error: ${e.message}`);
     d(e.stack);

--- a/src/build-project-main.js
+++ b/src/build-project-main.js
@@ -216,7 +216,7 @@ async function realMain(argv, showHelp) {
     let nwo = getNwoFromRepoUrl(repo);
 
     let gistInfo = await retryPromise(() => createGist(`Build completed: ${nwo}#${sha}, ${new Date()}`, { 
-      "README.md": { content: `## Build for ${nwo} ${buildPassed ? 'succeeded' : 'failed'} on ${Date.now()}` }
+      "README.md": { content: `## Build for ${nwo} ${buildPassed ? 'succeeded' : 'failed'} on ${new Date()}` }
     }));
 
     d(`Gist result: ${gistInfo.result.html_url}`);

--- a/src/build-project-main.js
+++ b/src/build-project-main.js
@@ -216,7 +216,7 @@ async function realMain(argv, showHelp) {
     let nwo = getNwoFromRepoUrl(repo);
 
     let gistInfo = await retryPromise(() => createGist(`Build completed: ${nwo}#${sha}, ${new Date()}`, { 
-      "README.md": `## Build for ${nwo} ${buildPassed ? 'succeeded' : 'failed'} on ${Date.now()}`
+      "README.md": { content: `## Build for ${nwo} ${buildPassed ? 'succeeded' : 'failed'} on ${Date.now()}` }
     }));
 
     d(`Gist result: ${gistInfo.result.html_url}`);

--- a/src/build-project-main.js
+++ b/src/build-project-main.js
@@ -1,5 +1,7 @@
 import path from 'path';
 import mkdirp from 'mkdirp';
+import sfs from 'fs';
+
 import { cloneOrFetchRepo, cloneRepo, checkoutSha, getWorkdirForRepoUrl,
   getTempdirForRepoUrl, getOriginForRepo, getHeadForRepo, resetOriginUrl } from './git-api';
 import { getSanitizedRepoUrl, getNwoFromRepoUrl, postCommitStatus, createGist,
@@ -56,7 +58,7 @@ export default function main(argv, showHelp) {
   ).take(1).toPromise();
 
   return doIt
-    .then(() => Promise.resolve(true), (e) => {
+    .then((x) => Promise.resolve(x), (e) => {
       d("Build being taken down!");
       if (argv.name) {
         let repo = argv.repo || process.env.SURF_REPO;
@@ -184,39 +186,36 @@ async function realMain(argv, showHelp) {
     cmds = [{cmd, args}];
   }
 
-  let buildPassed = false;
-  let buildOutput = null;
+  let buildPassed = true;
+  let buildLog = path.join(workDir, 'build-output.log');
+  let fd = await fs.open(buildLog, 'w');
 
   try {
     let buildStream = runAllBuildCommands(cmds, workDir, sha, tempDir);
 
-    buildOutput = '';
-    buildStream.subscribe((x) => {
-      buildOutput += x;
+    buildStream.concatMap((x) => {
       console.log(x.replace(/[\r\n]+$/, ''));
-    }, () => {});
+      return Observable.fromPromise(fs.write(fd, x, null, 'utf8'));
+    }).subscribe(() => {}, (e) => {
+      console.error(e.message);
+      sfs.writeSync(fd, `${e.message}\n`, null, 'utf8');
+    });
 
     await buildStream
       .reduce(() => null)
       .toPromise();
-
-    buildPassed = true;
-  } catch (e) {
-    buildOutput += `\n${e.message}`;
-    d(e.stack);
+  } catch (_) {
+    // NB: We log this in the subscribe statement above
+    buildPassed = false;
+  } finally {
+    sfs.closeSync(fd);
   }
-
-  await fs.writeFile(path.join(workDir, 'build-output.log'), buildOutput);
 
   if (name) {
     d(`Posting 'success' to GitHub status`);
     let nwo = getNwoFromRepoUrl(repo);
 
-    let gistInfo = await retryPromise(() => createGist(`Build completed: ${nwo}#${sha}, ${new Date()}`, {
-      "build-output.txt": {
-        content: buildOutput
-      }
-    }));
+    let gistInfo = await retryPromise(() => createGist(`Build completed: ${nwo}#${sha}, ${new Date()}`, { }));
 
     d(`Gist result: ${gistInfo.result.html_url}`);
     d(`Gist clone URL: ${gistInfo.result.git_pull_url}`);
@@ -241,7 +240,5 @@ async function realMain(argv, showHelp) {
     await rimraf(tempDir);
   }
 
-  if (!buildPassed) {
-    throw new Error(buildOutput);
-  }
+  return buildPassed ? 0 : -1;
 }

--- a/src/build-project-main.js
+++ b/src/build-project-main.js
@@ -221,18 +221,16 @@ async function realMain(argv, showHelp) {
 
     d(`Gist result: ${gistInfo.result.html_url}`);
     d(`Gist clone URL: ${gistInfo.result.git_pull_url}`);
-    if (buildPassed) {
-      let token = process.env.GIST_TOKEN || process.env.GITHUB_TOKEN;
+    let token = process.env.GIST_TOKEN || process.env.GITHUB_TOKEN;
 
-      try {
-        d(`Uploading build artifacts using token: ${token}`);
-        let targetDir = await retryPromise(() => 
-          uploadBuildArtifacts(gistInfo.result.id, gistInfo.result.git_pull_url, artifactDirs, buildLog, token));
-        await rimraf(targetDir);
-      } catch (e) {
-        console.error(`Failed to upload build artifacts: ${e.message}`);
-        d(e.stack);
-      }
+    try {
+      d(`Uploading build artifacts using token: ${token}`);
+      let targetDir = await retryPromise(() => 
+        uploadBuildArtifacts(gistInfo.result.id, gistInfo.result.git_pull_url, artifactDirs, buildLog, token));
+      await rimraf(targetDir);
+    } catch (e) {
+      console.error(`Failed to upload build artifacts: ${e.message}`);
+      d(e.stack);
     }
 
     await postCommitStatus(nwo, sha,

--- a/src/build-project-main.js
+++ b/src/build-project-main.js
@@ -226,7 +226,8 @@ async function realMain(argv, showHelp) {
 
       try {
         d(`Uploading build artifacts using token: ${token}`);
-        let targetDir = await retryPromise(() => uploadBuildArtifacts(gistInfo.result.id, gistInfo.result.git_pull_url, artifactDirs, token));
+        let targetDir = await retryPromise(() => 
+          uploadBuildArtifacts(gistInfo.result.id, gistInfo.result.git_pull_url, artifactDirs, buildLog, token));
         await rimraf(targetDir);
       } catch (e) {
         console.error(`Failed to upload build artifacts: ${e.message}`);

--- a/src/build-project-main.js
+++ b/src/build-project-main.js
@@ -225,9 +225,8 @@ async function realMain(argv, showHelp) {
 
     try {
       d(`Uploading build artifacts using token: ${token}`);
-      let targetDir = await retryPromise(() => 
+      await retryPromise(() => 
         uploadBuildArtifacts(gistInfo.result.id, gistInfo.result.git_pull_url, artifactDirs, buildLog, token));
-      await rimraf(targetDir);
     } catch (e) {
       console.error(`Failed to upload build artifacts: ${e.message}`);
       d(e.stack);

--- a/src/build-project-main.js
+++ b/src/build-project-main.js
@@ -212,10 +212,12 @@ async function realMain(argv, showHelp) {
   }
 
   if (name) {
-    d(`Posting 'success' to GitHub status`);
+    d(`Posting to GitHub status`);
     let nwo = getNwoFromRepoUrl(repo);
 
-    let gistInfo = await retryPromise(() => createGist(`Build completed: ${nwo}#${sha}, ${new Date()}`, { }));
+    let gistInfo = await retryPromise(() => createGist(`Build completed: ${nwo}#${sha}, ${new Date()}`, { 
+      "README.md": `## Build for ${nwo} ${buildPassed ? 'succeeded' : 'failed'} on ${Date.now()}`
+    }));
 
     d(`Gist result: ${gistInfo.result.html_url}`);
     d(`Gist clone URL: ${gistInfo.result.git_pull_url}`);

--- a/src/git-api.js
+++ b/src/git-api.js
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
 import path from 'path';
 import _ from 'lodash';
+import sfs from 'fs';
 
 import { Repository, Clone, Checkout, Cred, Reference, Signature, Remote, enableThreadSafety } from 'nodegit';
 import { getNwoFromRepoUrl } from './github-api';
@@ -49,6 +50,18 @@ export async function getAllWorkdirs(repoUrl) {
 
   return _.reduce(ret, (acc, x) => {
     let nwo = getNwoFromRepoUrl(repoUrl).split('/')[1];
+    if (x.match(/^surfg-/i)) {
+      let tgt = path.join(tmp, x);
+      let stats = fs.statSync(tgt);
+      let now = new Date();
+
+      if (now - stats.mtime > 1000 * 60 * 60 * 2) {
+        acc.push(path.join(tmp, x));
+      }
+
+      return acc;
+    }
+
     if (!x.match(/-[a-f0-9A-F]{6}/i)) return acc;
     if (x.indexOf(`${nwo}-`) < 0) return acc;
 


### PR DESCRIPTION
This PR cleans up a bunch of things:

1. Surf was printing the build output twice on failures which is silly
1. Surf was saving the build output as a string, which will overflow on large builds. Instead, stream it to disk / stdout
1. On build failure, we'd throw an error, which Surf would then stomp our GH status with a "Errored" status