### PR TITLE
Add the command as first element in ProgramArguments array, fixes #65

### DIFF
--- a/src/job-installers/launchd.plist.in
+++ b/src/job-installers/launchd.plist.in
@@ -21,6 +21,7 @@
     
     <key>ProgramArguments</key>
     <array>
+      <string><%= commandWithoutArgs %></string>
 <% print(argList.map((x) => `      <string>${x}</string>`).join("\n")) %>
     </array>
     


### PR DESCRIPTION
OP #65: surf-install doesn't work on OSX

The problem was that the first argument in the ProgramArguments array needs to be the command itself. 

I think this change to the template does the job.