### PR TITLE
Minor readme update: Mention need for write priv on token

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Surf will instead use any of the following files as the build command if they ar
 
 Now, let's test it out. First, we need to get a GitHub token:
 
-1. Go to https://github.com/settings/tokens to get a token
+1. Go to [https://github.com/settings/tokens](https://github.com/settings/tokens) to get a token (The user generating the token needs write/push privileges on the repo so surf-build can update statuses.)
 1. Make sure to check `repo` and `gist`.
 1. Generate the token and save it off
 


### PR DESCRIPTION
The privileges of the $GITHUB_TOKEN used are critical; the assumption in the readme is that the repo-owning user is generating the token, but that may not be the case. (I wanted to switch my build to a machine user and went down in flames :)

This just updates the README.md to mention the privileges required of the token-creating user.

Side-note: In the future it might be worth moving from GITHUB_TOKEN to SURF_GITHUB_TOKEN or some such, since there are many different tokens in my environment, and the fewer that have undifferentiated names, the better. homebrew, for example, uses HOMEBREW_GITHUB_TOKEN. 