### PR TITLE
Disable build cancellation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,6 @@ addons:
       - libstdc++6
 
 install:
-  - npm install -g surf-build@1.0.0-beta.3
+  - npm install -g surf-build@1.2.0-beta.7
 script:
   - surf-build -n "surf-travis-$TRAVIS_OS_NAME"

--- a/src/build-monitor.ts
+++ b/src/build-monitor.ts
@@ -39,7 +39,8 @@ export default class BuildMonitor {
       private fetchRefs: (() => Observable<[any]>),
       initialRefs?: [any],
       scheduler?: IScheduler,
-      private pollInterval = 5000) {
+      private pollInterval = 5000,
+      private enableCancellation = true) {
 
     this.scheduler = scheduler || Scheduler.queue;
     this.currentRunningMonitor = new SerialSubscription();
@@ -147,7 +148,7 @@ export default class BuildMonitor {
 
       // NB: We intentionally collect all of these via the reducer first to avoid
       // altering currentBuilds while iterating through it
-      cancellers.forEach((x) => x());
+      if (this.enableCancellation) cancellers.forEach((x) => x());
 
       let refsToBuild = this.determineRefsToBuild(refs);
 

--- a/src/run-on-every-ref-cli.ts
+++ b/src/run-on-every-ref-cli.ts
@@ -18,6 +18,8 @@ Monitors a GitHub repo and runs a command for each changed branch / PR.`)
   .alias('v', 'version')
   .describe('version', 'Print the current version number and exit')
   .alias('h', 'help')
+  .describe('no-cancel', 'Disable build cancellation - new pushes will not abort in-progress builds')
+  .boolean('no-cancel')
   .epilog(`
 Some useful environment variables:
 

--- a/src/run-on-every-ref-main.ts
+++ b/src/run-on-every-ref-main.ts
@@ -21,6 +21,7 @@ function getRandomInt(min: number, max: number) {
 export default async function main(argv: any, showHelp: () => void) {
   let cmdWithArgs = argv._;
   let repo = argv.r;
+  let enableCancellation = !argv['no-cancel'];
 
   if (argv.help) {
     showHelp();
@@ -64,7 +65,7 @@ export default async function main(argv: any, showHelp: () => void) {
   refInfo = await fetchRefsWithRetry.toPromise();
 
   console.log(`Watching ${repo}, will run '${cmdWithArgs.join(' ')}'\n`);
-  let buildMonitor = new BuildMonitor(cmdWithArgs, repo, jobs, () => fetchRefsWithRetry, refInfo);
+  let buildMonitor = new BuildMonitor(cmdWithArgs, repo, jobs, () => fetchRefsWithRetry, refInfo, undefined, undefined, enableCancellation);
   buildMonitor.start();
 
   // NB: This is a little weird - buildMonitorCrashed just returns an item


### PR DESCRIPTION
This PR gives you a flag to be able to disable cancelling builds when pushes happen, because for some crappy build systems this corrupts their global state