### PR TITLE
Simple Monorepo support

### DIFF
--- a/fixtures/diffstat.txt
+++ b/fixtures/diffstat.txt
@@ -1,0 +1,59 @@
+1	1	.travis.yml
+110	103	README.md
+5693	0	package-lock.json
+57	29	package.json
+7	0	src/ambient.d.ts
+0	3	src/babel-maybefill.js
+24	24	src/{build-api.js => build-api.ts}
+0	13	src/build-discover-base.js
+26	0	src/build-discover-base.ts
+8	7	src/build-discoverers/{autotools.js => autotools.ts}
+12	5	src/build-discoverers/{build-script.js => build-script.ts}
+7	7	src/build-discoverers/{cmake.js => cmake.ts}
+4	3	src/build-discoverers/{danger.js => danger.ts}
+19	13	src/build-discoverers/{dotnet.js => dotnet.ts}
+40	0	src/build-discoverers/monorepo.ts
+9	7	src/build-discoverers/{npm.js => npm.ts}
+9	5	src/build-discoverers/{rust.js => rust.ts}
+5	5	src/build-discoverers/{xcode.js => xcode.ts}
+44	23	src/{build-monitor.js => build-monitor.ts}
+6	2	src/{build-project-cli.js => build-project-cli.ts}
+47	52	src/{build-project-main.js => build-project-main.ts}
+7	3	src/{clean-workdirs-cli.js => clean-workdirs-cli.ts}
+9	9	src/{clean-workdirs-main.js => clean-workdirs-main.ts}
+8	4	src/{commit-status-cli.js => commit-status-cli.ts}
+13	10	src/{commit-status-main.js => commit-status-main.ts}
+0	32	src/custom-rx-operators.js
+44	0	src/custom-rx-operators.ts
+5	1	src/{download-release-cli.js => download-release-cli.ts}
+3	3	src/{download-release-main.js => download-release-main.ts}
+78	53	src/{git-api.js => git-api.ts}
+121	92	src/{github-api.js => github-api.ts}
+10	8	src/{job-installer-api.js => job-installer-api.ts}
+0	35	src/job-installer-base.js
+37	0	src/job-installer-base.ts
+10	5	src/{job-installer-cli.js => job-installer-cli.ts}
+7	7	src/{job-installer-main.js => job-installer-main.ts}
+28	22	src/job-installers/{docker.js => docker.ts}
+1	0	src/job-installers/launchd.plist.in
+30	27	src/job-installers/{launchd.js => launchd.ts}
+25	19	src/job-installers/{systemd.js => systemd.ts}
+40	36	src/job-installers/{task-scheduler.js => task-scheduler.ts}
+0	76	src/promise-array.js
+81	0	src/promise-array.ts
+0	18	src/promisify.js
+6	2	src/{publish-tag-cli.js => publish-tag-cli.ts}
+28	11	src/{publish-tag-main.js => publish-tag-main.ts}
+26	0	src/recursive-fs.ts
+8	2	src/{run-on-every-ref-cli.js => run-on-every-ref-cli.ts}
+17	17	src/{run-on-every-ref-main.js => run-on-every-ref-main.ts}
+113	0	src/sha-to-ref-cli.ts
+2	2	test/{asserttest.js => asserttest.ts}
+31	26	test/{build-monitor.js => build-monitor.ts}
+5	8	test/{build-project-integration-tests.js => build-project-integration-tests.ts}
+6	3	test/{git-api.js => git-api.ts}
+23	20	test/{job-installers.js => job-installers.ts}
+0	12	test/support.js
+5	0	test/support.ts
+33	0	tsconfig.json
+36	0	tslint.json

--- a/src/build-api.ts
+++ b/src/build-api.ts
@@ -58,7 +58,12 @@ export async function determineBuildCommands(rootPath: string, sha: string) {
     let thisCmd = await discoverer.getBuildCommand(sha);
 
     d(`Discoverer returned ${JSON.stringify(thisCmd)}`);
-    let newCmds = thisCmd.cmds.map((x) => findActualExecutable(x.cmd, x.args));
+    let newCmds = thisCmd.cmds.map((x) => {
+      return {
+        ...findActualExecutable(x.cmd, x.args),
+        cwd: x.cwd
+      };
+    });
     ret.cmds.push(...newCmds);
 
     if (thisCmd.artifactDirs) {
@@ -71,8 +76,8 @@ export async function determineBuildCommands(rootPath: string, sha: string) {
 }
 
 export function runAllBuildCommands(cmds: BuildCommand[], rootDir: string, sha: string, tempDir: string) {
-  let toConcat = cmds.map(({cmd, args}) => {
-    return runBuildCommand(cmd, args, rootDir, sha, tempDir);
+  let toConcat = cmds.map(({cmd, args, cwd}) => {
+    return runBuildCommand(cmd, args, cwd || rootDir, sha, tempDir);
   });
 
   return Observable.concat(...toConcat)

--- a/src/build-discover-base.ts
+++ b/src/build-discover-base.ts
@@ -20,7 +20,7 @@ export default class BuildDiscoverBase {
     throw new Error("Implement me!");
   }
 
-  getBuildCommand(_sha: string): Promise<BuildCommandResult>  {
+  getBuildCommand(_sha: string): Promise<BuildCommandResult> {
     throw new Error("Implement me!");
   }
 }

--- a/src/build-discover-base.ts
+++ b/src/build-discover-base.ts
@@ -1,6 +1,7 @@
 export interface BuildCommand {
   cmd: string;
   args: string[];
+  cwd: string;
 }
 
 export interface BuildCommandResult {
@@ -17,10 +18,10 @@ export default class BuildDiscoverBase {
   }
 
   getAffinityForRootDir(): Promise<number>  {
-    throw new Error("Implement me!");
+    throw new Error('Implement me!');
   }
 
   getBuildCommand(_sha: string): Promise<BuildCommandResult> {
-    throw new Error("Implement me!");
+    throw new Error('Implement me!');
   }
 }

--- a/src/build-discoverers/autotools.ts
+++ b/src/build-discoverers/autotools.ts
@@ -21,14 +21,14 @@ export default class AutotoolsBuildDiscoverer extends BuildDiscoverBase {
 
   async getBuildCommand() {
     let cmds = [
-      { cmd: path.join(this.rootDir, 'configure'), args: ['--prefix', path.resolve(this.rootDir, 'surf-artifacts')] },
-      { cmd: 'make', args: []},
-      { cmd: 'make', args: ['install']}
+      { cmd: path.join(this.rootDir, 'configure'), args: ['--prefix', path.resolve(this.rootDir, 'surf-artifacts')], cwd: this.rootDir },
+      { cmd: 'make', args: [], cwd: this.rootDir},
+      { cmd: 'make', args: ['install'], cwd: this.rootDir }
     ];
 
     let autogen = path.join(this.rootDir, 'autogen.sh');
     if (await statNoException(autogen)) {
-      cmds.unshift({ cmd: autogen, args: [] });
+      cmds.unshift({ cmd: autogen, args: [], cwd: this.rootDir });
     }
 
     d(JSON.stringify(cmds));

--- a/src/build-discoverers/build-script.ts
+++ b/src/build-discoverers/build-script.ts
@@ -4,6 +4,7 @@ import {mkdirp} from '../recursive-fs';
 
 import BuildDiscoverBase, { BuildCommand } from '../build-discover-base';
 
+// tslint:disable-next-line:no-var-requires
 const d = require('debug')('surf:build-discover-drivers');
 
 const possibleScriptPathsWin32 = [
@@ -41,7 +42,7 @@ export default class BuildScriptDiscoverer extends BuildDiscoverBase {
         d(`Looking for file ${fullPath}`);
         let stat = await fs.stat(fullPath);
 
-        d("Found it!");
+        d('Found it!');
         if (stat) return fullPath;
       } catch (e) {
         continue;
@@ -57,11 +58,11 @@ export default class BuildScriptDiscoverer extends BuildDiscoverBase {
     await mkdirp(artifactDir);
 
     process.env.SURF_ARTIFACT_DIR = artifactDir;
-    let cmd: BuildCommand = { cmd: await this.getScriptPath() || "", args: [], }
+    let cmd: BuildCommand = { cmd: await this.getScriptPath() || '', args: [], cwd: this.rootDir };
 
-    return { 
+    return {
       cmds: [cmd],
-      artifactDirs: [artifactDir] 
+      artifactDirs: [artifactDir]
     };
   }
 }

--- a/src/build-discoverers/cmake.ts
+++ b/src/build-discoverers/cmake.ts
@@ -21,13 +21,13 @@ export default class AutotoolsBuildDiscoverer extends BuildDiscoverBase {
   async getBuildCommand() {
     let prefix = path.resolve(this.rootDir, 'surf-artifacts');
     let cmds = [
-      { cmd: 'cmake', args: [`-DCMAKE_INSTALL_PREFIX:PATH=${prefix}`, '.']},
-      { cmd: 'make', args: ['all', 'install']}
+      { cmd: 'cmake', args: [`-DCMAKE_INSTALL_PREFIX:PATH=${prefix}`, '.'], cwd: this.rootDir },
+      { cmd: 'make', args: ['all', 'install'], cwd: this.rootDir }
     ];
 
     let autogen = path.join(this.rootDir, 'autogen.sh');
     if (await statNoException(autogen)) {
-      cmds.unshift({ cmd: autogen, args: [] });
+      cmds.unshift({ cmd: autogen, args: [], cwd: this.rootDir });
     }
 
     d(JSON.stringify(cmds));

--- a/src/build-discoverers/danger.ts
+++ b/src/build-discoverers/danger.ts
@@ -33,8 +33,8 @@ export default class DangerBuildDiscoverer extends BuildDiscoverBase {
 
   async getBuildCommand() {
     let cmds = [
-      { cmd: 'bundle', args: ['install']},
-      { cmd: 'bundle', args: ['exec', 'danger']}
+      { cmd: 'bundle', args: ['install'], cwd: this.rootDir },
+      { cmd: 'bundle', args: ['exec', 'danger'], cwd: this.rootDir }
     ];
 
     if (!process.env.SURF_BUILD_NAME) {

--- a/src/build-discoverers/dotnet.ts
+++ b/src/build-discoverers/dotnet.ts
@@ -55,7 +55,7 @@ export default class DotNetBuildDiscoverer extends BuildDiscoverBase {
 
     let artifactDirs = projFiles.map((x) => path.join(path.dirname(x), 'bin', 'Release'));
 
-    let cmd = { cmd: buildCommand, args: ['/p:Configuration=Release', slnFile] };
+    let cmd = { cmd: buildCommand, args: ['/p:Configuration=Release', slnFile], cwd: this.rootDir };
 
     return {
       cmds: [cmd],

--- a/src/build-discoverers/dotnet.ts
+++ b/src/build-discoverers/dotnet.ts
@@ -1,16 +1,11 @@
 import * as path from 'path';
 import * as fs from 'mz/fs';
 
-import {statNoException, readdirRecursive} from '../promise-array';
+import {statNoException, readdirRecursive, uniq} from '../promise-array';
 import BuildDiscoverBase from '../build-discover-base';
 
 // tslint:disable-next-line:no-var-requires
 const d = require('debug')('surf:build-discover-dotnet');
-
-function uniq(list: string[]): string[] {
-  return Object.keys(
-    list.reduce((acc, x) => { acc[x] = true; return acc; }, {}));
-}
 
 export default class DotNetBuildDiscoverer extends BuildDiscoverBase {
   constructor(rootDir: string) {

--- a/src/build-discoverers/monorepo.ts
+++ b/src/build-discoverers/monorepo.ts
@@ -1,8 +1,8 @@
 import * as path from 'path';
 import * as fs from 'mz/fs';
 
-import {statNoException, readdirRecursive, uniq, asyncReduce} from '../promise-array';
-import BuildDiscoverBase, { BuildCommandResult, BuildCommand } from '../build-discover-base';
+import {statNoException, uniq, asyncReduce} from '../promise-array';
+import BuildDiscoverBase, { BuildCommandResult } from '../build-discover-base';
 import { getChangedFiles } from '../git-api';
 import { determineBuildCommands } from '../build-api';
 
@@ -22,14 +22,17 @@ export default class MonoRepoBuildDiscoverer extends BuildDiscoverBase {
   }
 
   async getAffinityForRootDir() {
+    d('Starting search for Monorepo');
     if (MonoRepoBuildDiscoverer.ignoreSelf) return 0;
 
     const surfPath = path.join(this.rootDir, '.surf.json');
     if (!statNoException(surfPath)) return 0;
 
     try {
+      d(`Reading configuration from ${surfPath}`);
       this.surfConfiguration = JSON.parse(fs.readFileSync(surfPath, 'utf8'));
     } catch (e) {
+      d(`Failed to parse Monorepo JSON: ${e.message}`);
       return 0;
     }
 
@@ -37,24 +40,29 @@ export default class MonoRepoBuildDiscoverer extends BuildDiscoverBase {
       !this.surfConfiguration.projects ||
       this.surfConfiguration.projects.length < 1) return 0;
 
+    d(`Found a Monorepo with projects: ${JSON.stringify(this.surfConfiguration!.projects)}`);
     return 50;
   }
 
   async getBuildCommand(sha: string): Promise<BuildCommandResult> {
     const files = await getChangedFiles(this.rootDir);
-    const projects = this.surfConfiguration!.projects.map(x => x.toLowerCase());
+    const projects = this.surfConfiguration!.projects
+      .map(x => x.toLowerCase());
 
     let projectsToBuild = files.map(f => {
       return projects.reduce((acc: string, p: string) => {
+        d(`Is ${p} a prefix of ${f}?`);
         if (f.indexOf(p) !== 0) return acc;
+        d('It is!');
         if (acc.length < 1) return p;
 
         return (acc.length >= p.length) ? acc : p;
       }, '');
     });
 
+    d(`Projects: ${JSON.stringify(projectsToBuild)}`);
     projectsToBuild = uniq(projectsToBuild.filter(x => x && x.length > 2).sort());
-    console.error(`Projects to Build:\n================\n${projectsToBuild.join()}`);
+    d(`Projects to Build:\n================\n${projectsToBuild.join()}`);
 
     MonoRepoBuildDiscoverer.ignoreSelf = true;
     try {

--- a/src/build-discoverers/monorepo.ts
+++ b/src/build-discoverers/monorepo.ts
@@ -1,8 +1,10 @@
 import * as path from 'path';
 import * as fs from 'mz/fs';
 
-import {statNoException, readdirRecursive} from '../promise-array';
-import BuildDiscoverBase from '../build-discover-base';
+import {statNoException, readdirRecursive, uniq, asyncReduce} from '../promise-array';
+import BuildDiscoverBase, { BuildCommandResult, BuildCommand } from '../build-discover-base';
+import { getChangedFiles } from '../git-api';
+import { determineBuildCommands } from '../build-api';
 
 // tslint:disable-next-line:no-var-requires
 const d = require('debug')('surf:build-discover-monorepo');
@@ -13,12 +15,15 @@ export interface SurfConfiguration {
 
 export default class MonoRepoBuildDiscoverer extends BuildDiscoverBase {
   private surfConfiguration?: SurfConfiguration;
+  private static ignoreSelf = false;
 
   constructor(rootDir: string) {
     super(rootDir);
   }
 
   async getAffinityForRootDir() {
+    if (MonoRepoBuildDiscoverer.ignoreSelf) return 0;
+
     const surfPath = path.join(this.rootDir, '.surf.json');
     if (!statNoException(surfPath)) return 0;
 
@@ -35,6 +40,33 @@ export default class MonoRepoBuildDiscoverer extends BuildDiscoverBase {
     return 50;
   }
 
-  async getBuildCommand(sha: string) {
+  async getBuildCommand(sha: string): Promise<BuildCommandResult> {
+    const files = await getChangedFiles(this.rootDir);
+    const projects = this.surfConfiguration!.projects.map(x => x.toLowerCase());
+
+    let projectsToBuild = files.map(f => {
+      return projects.reduce((acc: string, p: string) => {
+        if (f.indexOf(p) !== 0) return acc;
+        if (acc.length < 1) return p;
+
+        return (acc.length >= p.length) ? acc : p;
+      }, '');
+    });
+
+    projectsToBuild = uniq(projectsToBuild.filter(x => x && x.length > 2).sort());
+    console.error(`Projects to Build:\n================\n${projectsToBuild.join()}`);
+
+    MonoRepoBuildDiscoverer.ignoreSelf = true;
+    try {
+      return await asyncReduce(projectsToBuild, async (acc: BuildCommandResult, x: string) => {
+        let thisProject = await determineBuildCommands(path.join(this.rootDir, x), sha);
+        acc.cmds.push(...thisProject.cmds);
+        if (thisProject.artifactDirs) acc.artifactDirs!.push(...thisProject.artifactDirs);
+
+        return acc;
+      }, { cmds: [], artifactDirs: [] });
+    } finally {
+      MonoRepoBuildDiscoverer.ignoreSelf = false;
+    }
   }
 }

--- a/src/build-discoverers/monorepo.ts
+++ b/src/build-discoverers/monorepo.ts
@@ -1,0 +1,40 @@
+import * as path from 'path';
+import * as fs from 'mz/fs';
+
+import {statNoException, readdirRecursive} from '../promise-array';
+import BuildDiscoverBase from '../build-discover-base';
+
+// tslint:disable-next-line:no-var-requires
+const d = require('debug')('surf:build-discover-monorepo');
+
+export interface SurfConfiguration {
+  projects: string[];
+}
+
+export default class MonoRepoBuildDiscoverer extends BuildDiscoverBase {
+  private surfConfiguration?: SurfConfiguration;
+
+  constructor(rootDir: string) {
+    super(rootDir);
+  }
+
+  async getAffinityForRootDir() {
+    const surfPath = path.join(this.rootDir, '.surf.json');
+    if (!statNoException(surfPath)) return 0;
+
+    try {
+      this.surfConfiguration = JSON.parse(fs.readFileSync(surfPath, 'utf8'));
+    } catch (e) {
+      return 0;
+    }
+
+    if (!this.surfConfiguration ||
+      !this.surfConfiguration.projects ||
+      this.surfConfiguration.projects.length < 1) return 0;
+
+    return 50;
+  }
+
+  async getBuildCommand(sha: string) {
+  }
+}

--- a/src/build-discoverers/npm.ts
+++ b/src/build-discoverers/npm.ts
@@ -25,11 +25,11 @@ export default class NpmBuildDiscoverer extends BuildDiscoverBase {
       await fs.readFile(path.join(this.rootDir, 'package.json'), 'utf8'));
 
     let cmds = [
-      { cmd: 'npm', args: ['install']}
+      { cmd: 'npm', args: ['install'], cwd: this.rootDir }
     ];
 
     if (pkgJson.scripts && pkgJson.scripts.test) {
-      cmds.push({ cmd: 'npm', args: ['test']});
+      cmds.push({ cmd: 'npm', args: ['test'], cwd: this.rootDir });
     }
 
     return {cmds};

--- a/src/build-discoverers/rust.ts
+++ b/src/build-discoverers/rust.ts
@@ -21,7 +21,7 @@ export default class RustBuildDiscoverer extends BuildDiscoverBase {
 
   async getBuildCommand() {
     process.env.RUST_BACKTRACE = '1';
-    let cmd = { cmd: 'cargo', args: ['test', '-v'] };
+    let cmd = { cmd: 'cargo', args: ['test', '-v'], cwd: this.rootDir };
 
     return { cmds: [cmd] };
   }

--- a/src/build-discoverers/xcode.ts
+++ b/src/build-discoverers/xcode.ts
@@ -12,7 +12,7 @@ export default class XcodeBuildDiscoverer extends BuildDiscoverBase {
   }
 
   async getBuildCommand() {
-    let cmd = { cmd: 'xcodebuild', args: []};
+    let cmd = { cmd: 'xcodebuild', args: [], cwd: this.rootDir };
     return { cmds: [cmd] };
   }
 }

--- a/src/git-api.ts
+++ b/src/git-api.ts
@@ -49,6 +49,7 @@ export async function getOriginForRepo(targetDirname: string) {
 
 export async function getOriginDefaultBranchName(targetDirname: string, token?: string) {
   let repoDir = await Repository.discover(targetDirname, 0, '');
+  token = token || process.env.GITHUB_TOKEN;
 
   return await using(async (ds) => {
     let repo = ds(await Repository.open(repoDir));
@@ -115,12 +116,13 @@ export function parseGitDiffOutput(output: string): string[] {
     });
 }
 
-export async function getChangedFiles(targetDirname: string): Promise<string[]> {
+export async function getChangedFiles(targetDirname: string, token?: string): Promise<string[]> {
   let opts = { cwd: targetDirname };
+  token = token || process.env.GITHUB_TOKEN;
 
   let ourCommit = (await getHeadForRepo(targetDirname));
   d(`Got our commit: ${ourCommit}`);
-  let defaultRemoteBranch = await getOriginDefaultBranchName(targetDirname);
+  let defaultRemoteBranch = await getOriginDefaultBranchName(targetDirname, token);
 
   d(`Using origin/${defaultRemoteBranch} as remote default branch`);
   let remoteHeadCommit = (await spawnPromise('git', ['rev-parse', `origin/${defaultRemoteBranch}`], opts)).trim();
@@ -137,7 +139,7 @@ export async function getChangedFiles(targetDirname: string): Promise<string[]> 
     await spawnPromise('git', ['diff', '--numstat', 'origin/HEAD...HEAD']));
 }
 
-export function getWorkdirForRepoUrl(repoUrl: string, sha: string, dontCreate= false) {
+export function getWorkdirForRepoUrl(repoUrl: string, sha: string, dontCreate = false) {
   let tmp = process.env.TMPDIR || process.env.TEMP || '/tmp';
   let nwo = getNwoFromRepoUrl(repoUrl).split('/')[1];
   let date = toIso8601(new Date()).replace(/:/g, '.');
@@ -153,7 +155,7 @@ export function getWorkdirForRepoUrl(repoUrl: string, sha: string, dontCreate= f
   return ret;
 }
 
-export function getTempdirForRepoUrl(repoUrl: string, sha: string, dontCreate= false) {
+export function getTempdirForRepoUrl(repoUrl: string, sha: string, dontCreate = false) {
   let tmp = process.env.TMPDIR || process.env.TEMP || '/tmp';
   let nwo = getNwoFromRepoUrl(repoUrl).split('/')[1];
   let date = toIso8601(new Date()).replace(/:/g, '.');

--- a/src/promise-array.ts
+++ b/src/promise-array.ts
@@ -79,3 +79,8 @@ export async function readdirRecursive(dir: string): Promise<string[]> {
 
   return acc;
 }
+
+export function uniq(list: string[]): string[] {
+  return Object.keys(
+    list.reduce((acc, x) => { acc[x] = true; return acc; }, {}));
+}

--- a/test/git-api.ts
+++ b/test/git-api.ts
@@ -2,7 +2,7 @@ import './support';
 import {expect} from 'chai';
 
 import * as path from 'path';
-import { cloneRepo, fetchRepo, cloneOrFetchRepo } from '../src/git-api';
+import { cloneRepo, fetchRepo, cloneOrFetchRepo, parseGitDiffOutput } from '../src/git-api';
 import { rimraf, mkdirp } from '../src/recursive-fs';
 import * as fs from 'mz/fs';
 
@@ -49,5 +49,17 @@ describe('The node-git helper methods', function() {
 
     let result = await fs.stat(path.join(repoDir, 'HEAD'));
     expect(result).to.be.ok;
+  });
+});
+
+describe.only('The parseGitDiffOutput function', function() {
+  let diffStatFile = path.join(__dirname, '..', 'fixtures', 'diffstat.txt');
+  let fixtureData = fs.readFileSync(diffStatFile, 'utf8');
+
+  it('should parse the fixture file', () => {
+    let result = parseGitDiffOutput(fixtureData);
+
+    expect(result).to.contain('src/build-discover-base.ts');
+    expect(result).to.contain('test/job-installers.ts');
   });
 });

--- a/test/git-api.ts
+++ b/test/git-api.ts
@@ -52,7 +52,7 @@ describe('The node-git helper methods', function() {
   });
 });
 
-describe.only('The parseGitDiffOutput function', function() {
+describe('The parseGitDiffOutput function', function() {
   let diffStatFile = path.join(__dirname, '..', 'fixtures', 'diffstat.txt');
   let fixtureData = fs.readFileSync(diffStatFile, 'utf8');
 


### PR DESCRIPTION
This PR adds the ability to build >1 project out of the same repository. To do this, declare a top-level `.surf.json` file:

```json
{
  "projects": ["src/project1", "src/project2"]
}
```

Surf will now build the entire set of projects on the master branch, and attempt to only build projects whose files have changed in PRs